### PR TITLE
Add KeychainService for secure Codable storage

### DIFF
--- a/CepteBul/KeychainService.swift
+++ b/CepteBul/KeychainService.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Security
+
+struct KeychainService {
+    enum KeychainError: Error {
+        case encodingFailed(Error)
+        case decodingFailed(Error)
+        case unexpectedStatus(OSStatus)
+    }
+
+    func save<T: Codable>(item: T, service: String, account: String) throws {
+        let encoder = JSONEncoder()
+        let data: Data
+        do {
+            data = try encoder.encode(item)
+        } catch {
+            throw KeychainError.encodingFailed(error)
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            let attributes: [String: Any] = [kSecValueData as String: data]
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrService as String: service,
+                kSecAttrAccount as String: account
+            ]
+            let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            guard updateStatus == errSecSuccess else {
+                throw KeychainError.unexpectedStatus(updateStatus)
+            }
+        } else if status != errSecSuccess {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func read<T: Codable>(service: String, account: String) throws -> T? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else { return nil }
+            do {
+                return try JSONDecoder().decode(T.self, from: data)
+            } catch {
+                throw KeychainError.decodingFailed(error)
+            }
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    func delete(service: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add generic KeychainService for saving, reading and deleting `Codable` items in the keychain
- ensure stored items use `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` and a `KeychainError` enum for error handling

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68963a13f95c8323b517183080d2415a