### PR TITLE
Fix immutable self error in LoginView

### DIFF
--- a/CepteBul/Features/Login/LoginView.swift
+++ b/CepteBul/Features/Login/LoginView.swift
@@ -11,8 +11,14 @@ struct LoginView: View {
     @State private var isLoggedIn = false
 
     // MARK: - Dependencies
-    private let tokenStore = TokenStore()
-    private lazy var authService = AuthService(client: APIClient(), tokenStore: tokenStore)
+    private let tokenStore: TokenStore
+    private let authService: AuthService
+
+    init() {
+        let tokenStore = TokenStore()
+        self.tokenStore = tokenStore
+        self.authService = AuthService(client: APIClient(), tokenStore: tokenStore)
+    }
 
     var body: some View {
         VStack {


### PR DESCRIPTION
## Summary
- avoid mutating getter warning by initializing tokenStore and authService in init

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6897651a62948323b9b003a615943e88