### PR TITLE
Add login persistence and business navigation

### DIFF
--- a/CepteBul/ContentView.swift
+++ b/CepteBul/ContentView.swift
@@ -1,58 +1,22 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var email: String = ""
-    @State private var password: String = ""
-    @State private var showEmailError: Bool = false
-    @State private var isLoggedIn: Bool = false
+    @State private var isLoggedIn = false
+    private let tokenStore = TokenStore()
 
     var body: some View {
-        NavigationStack {
-            VStack(spacing: 16) {
-                Spacer()
-                if showEmailError {
-                    Text("hatalı mail girdiniz!")
-                        .foregroundColor(.red)
-                        .font(.caption)
-                        .transition(.move(edge: .top))
-                }
-                TextField("Mail", text: $email)
-                    .keyboardType(.emailAddress)
-                    .textInputAutocapitalization(.never)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                SecureField("Şifre", text: $password)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                Button("Giriş yap") {
-                    handleLogin()
-                }
-                NavigationLink("", destination: HomeView(), isActive: $isLoggedIn)
-                    .hidden()
-                Spacer()
-            }
-            .padding()
-        }
-    }
-
-    private func handleLogin() {
-        if isValidEmail(email) && password.count >= 6 {
-            isLoggedIn = true
-        } else {
-            if !isValidEmail(email) {
-                withAnimation {
-                    showEmailError = true
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    withAnimation {
-                        showEmailError = false
-                    }
-                }
+        Group {
+            if isLoggedIn {
+                HomeView(tokenStore: tokenStore)
+            } else {
+                LoginView(isLoggedIn: $isLoggedIn, tokenStore: tokenStore)
             }
         }
-    }
-
-    private func isValidEmail(_ email: String) -> Bool {
-        let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"
-        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
+        .task {
+            if await tokenStore.getAccessToken() != nil {
+                isLoggedIn = true
+            }
+        }
     }
 }
 

--- a/CepteBul/Features/BusinessList/BusinessDetailView.swift
+++ b/CepteBul/Features/BusinessList/BusinessDetailView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct BusinessDetailView: View {
+    let business: Business
+
+    var body: some View {
+        Text(business.name)
+            .font(.title)
+            .padding()
+    }
+}
+
+#Preview {
+    BusinessDetailView(business: Business(id: "1", name: "Örnek İşletme", location: "İstanbul"))
+}

--- a/CepteBul/Features/BusinessList/BusinessListView.swift
+++ b/CepteBul/Features/BusinessList/BusinessListView.swift
@@ -2,15 +2,29 @@ import SwiftUI
 
 struct BusinessListView: View {
     @StateObject var viewModel: BusinessListViewModel
-    
+
     var body: some View {
-        List(viewModel.businesses, id: \.id) { business in
-            VStack(alignment: .leading) {
-                Text(business.name)
-                Text(business.location)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                ForEach(viewModel.businesses, id: \.id) { business in
+                    NavigationLink(destination: BusinessDetailView(business: business)) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(business.name)
+                                .font(.headline)
+                            Text(business.location)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.2))
+                        )
+                    }
+                }
             }
+            .padding()
         }
         .task { await viewModel.load() }
     }

--- a/CepteBul/Features/Login/LoginView.swift
+++ b/CepteBul/Features/Login/LoginView.swift
@@ -8,16 +8,16 @@ struct LoginView: View {
     @State private var email = ""
     @State private var password = ""
     @State private var error: String?
-    @State private var isLoggedIn = false
+    @Binding var isLoggedIn: Bool
 
     // MARK: - Dependencies
     private let tokenStore: TokenStore
     private let authService: AuthService
 
-    init() {
-        let tokenStore = TokenStore()
+    init(isLoggedIn: Binding<Bool>, tokenStore: TokenStore) {
+        self._isLoggedIn = isLoggedIn
         self.tokenStore = tokenStore
-        self.authService = AuthService(client: APIClient(), tokenStore: tokenStore)
+        self.authService = AuthService(client: APIClient(tokenStore: tokenStore), tokenStore: tokenStore)
     }
 
     var body: some View {
@@ -33,11 +33,6 @@ struct LoginView: View {
 
             Button("Giriş Yap") {
                 Task { await login() }
-            }
-
-            if isLoggedIn {
-                Text("Başarıyla giriş yapıldı")
-                    .foregroundColor(.green)
             }
         }
         .padding()
@@ -62,6 +57,6 @@ struct LoginView: View {
 }
 
 #Preview {
-    LoginView()
+    LoginView(isLoggedIn: .constant(false), tokenStore: TokenStore())
 }
 

--- a/CepteBul/HomeView.swift
+++ b/CepteBul/HomeView.swift
@@ -1,16 +1,32 @@
 import SwiftUI
 
 struct HomeView: View {
+    private let tokenStore: TokenStore
+
+    init(tokenStore: TokenStore) {
+        self.tokenStore = tokenStore
+    }
+
     var body: some View {
-        VStack {
-            Spacer()
-            Text("Hoş geldiniz")
-                .font(.largeTitle)
-            Spacer()
+        TabView {
+            Text("Keşfet")
+                .tabItem { Label("Keşfet", systemImage: "magnifyingglass") }
+
+            NavigationStack {
+                BusinessListView(
+                    viewModel: BusinessListViewModel(
+                        service: BusinessService(client: APIClient(tokenStore: tokenStore))
+                    )
+                )
+            }
+            .tabItem { Label("Ana Sayfa", systemImage: "house") }
+
+            Text("Profil")
+                .tabItem { Label("Profil", systemImage: "person") }
         }
     }
 }
 
 #Preview {
-    HomeView()
+    HomeView(tokenStore: TokenStore())
 }

--- a/CepteBul/Networking/Auth/TokenStore.swift
+++ b/CepteBul/Networking/Auth/TokenStore.swift
@@ -1,27 +1,38 @@
 import Foundation
 
 actor TokenStore {
+    private let accessKey = "accessToken"
+    private let refreshKey = "refreshToken"
+    private let defaults = UserDefaults.standard
+
     private var accessToken: String?
     private var refreshToken: String?
-    
+
+    init() {
+        accessToken = defaults.string(forKey: accessKey)
+        refreshToken = defaults.string(forKey: refreshKey)
+    }
+
     func getAccessToken() -> String? {
         accessToken
     }
-    
+
     func setAccessToken(_ token: String?) {
         accessToken = token
+        defaults.set(token, forKey: accessKey)
     }
-    
+
     func getRefreshToken() -> String? {
         refreshToken
     }
-    
+
     func setRefreshToken(_ token: String?) {
         refreshToken = token
+        defaults.set(token, forKey: refreshKey)
     }
-    
+
     func set(tokens: AuthTokenResponse) {
-        accessToken = tokens.accessToken
-        refreshToken = tokens.refreshToken
+        setAccessToken(tokens.accessToken)
+        setRefreshToken(tokens.refreshToken)
     }
 }


### PR DESCRIPTION
## Summary
- persist auth tokens using `UserDefaults` to keep users signed in
- display login screen or main tab view based on auth state
- show businesses as tappable cards with detail view

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68977604e4c48323a668abb8e50ecb8e