### PR TITLE
Refresh token only for authorized requests

### DIFF
--- a/CepteBul/Networking/APIClient.swift
+++ b/CepteBul/Networking/APIClient.swift
@@ -27,7 +27,10 @@ final class APIClient {
             guard let http = response as? HTTPURLResponse else {
                 throw APIError(code: nil, message: "Invalid response", details: nil)
             }
-            if http.statusCode == 401, !didRefresh, endpoint.path != Endpoint.refresh().path {
+            if http.statusCode == 401,
+               endpoint.requiresAuth,
+               !didRefresh,
+               endpoint.path != Endpoint.refresh().path {
                 try await refreshToken()
                 return try await perform(endpoint: endpoint, body: body, attempt: attempt, didRefresh: true)
             }


### PR DESCRIPTION
## Summary
- avoid automatic token refresh on unauthorized endpoints by requiring `endpoint.requiresAuth`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68977d2524848323b7f80a2a87438979