### PR TITLE
Add tabbed home page with business grid

### DIFF
--- a/CepteBul/Features/BusinessList/BusinessListView.swift
+++ b/CepteBul/Features/BusinessList/BusinessListView.swift
@@ -3,15 +3,25 @@ import CepteBulNetworking
 
 struct BusinessListView: View {
     @StateObject var viewModel: BusinessListViewModel
-    
+    private let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
     var body: some View {
-        List(viewModel.businesses, id: \.id) { business in
-            VStack(alignment: .leading) {
-                Text(business.name)
-                Text(business.location)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(viewModel.businesses, id: \.id) { business in
+                    Button(action: {
+                        print("Tapped \(business.name)")
+                    }) {
+                        Text(business.name)
+                            .frame(maxWidth: .infinity, minHeight: 80)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.primary)
+                            )
+                    }
+                }
             }
+            .padding()
         }
         .task { await viewModel.load() }
     }

--- a/CepteBul/HomeView.swift
+++ b/CepteBul/HomeView.swift
@@ -1,12 +1,27 @@
 import SwiftUI
+import CepteBulNetworking
 
 struct HomeView: View {
     var body: some View {
-        VStack {
-            Spacer()
-            Text("Hoş geldiniz")
-                .font(.largeTitle)
-            Spacer()
+        TabView {
+            BusinessListView(
+                viewModel: BusinessListViewModel(
+                    service: BusinessService(client: APIClient())
+                )
+            )
+            .tabItem {
+                Label("Ana Sayfa", systemImage: "house")
+            }
+
+            Text("Keşfet")
+                .tabItem {
+                    Label("Keşfet", systemImage: "magnifyingglass")
+                }
+
+            Text("Profil")
+                .tabItem {
+                    Label("Profil", systemImage: "person")
+                }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace placeholder home view with tabbed interface for Home, Explore, and Profile
- Show businesses in a tappable grid on the Home tab

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6897ba27d6488323bca1225a108f9ea4